### PR TITLE
Add factorial endpoint to calculator API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,20 @@ function squareRoot(n) {
   return Math.sqrt(n);
 }
 
+function factorial(n) {
+  if (n < 0) {
+    throw new Error('Cannot calculate factorial of negative number');
+  }
+  if (n === 0 || n === 1) {
+    return 1;
+  }
+  let result = 1;
+  for (let i = 2; i <= n; i++) {
+    result *= i;
+  }
+  return result;
+}
+
 module.exports = {
   add,
   subtract,
@@ -59,6 +73,7 @@ module.exports = {
   modulo,
   power,
   squareRoot,
+  factorial,
   validateApiKey
 };
 

--- a/src/test.js
+++ b/src/test.js
@@ -1,4 +1,4 @@
-const { add, subtract, multiply, divide, modulo, power, squareRoot, validateApiKey } = require('./index');
+const { add, subtract, multiply, divide, modulo, power, squareRoot, factorial, validateApiKey } = require('./index');
 
 let passed = 0;
 let failed = 0;
@@ -43,6 +43,11 @@ test('modulo: 10 % 3 = 1', () => assertEqual(modulo(10, 3), 1));
 test('modulo: 20 % 7 = 6', () => assertEqual(modulo(20, 7), 6));
 test('modulo: 15 % 5 = 0', () => assertEqual(modulo(15, 5), 0));
 test('modulo: throws error on modulo by zero', () => assertThrows(() => modulo(10, 0), 'Division by zero'));
+test('factorial: 0! = 1', () => assertEqual(factorial(0), 1));
+test('factorial: 1! = 1', () => assertEqual(factorial(1), 1));
+test('factorial: 5! = 120', () => assertEqual(factorial(5), 120));
+test('factorial: 10! = 3628800', () => assertEqual(factorial(10), 3628800));
+test('factorial: throws error on negative number', () => assertThrows(() => factorial(-1), 'Cannot calculate factorial of negative number'));
 
 // Premium feature tests (require TEST_API_KEY env variable)
 console.log('\n--- Premium Features (require TEST_API_KEY) ---');

--- a/src/worker.js
+++ b/src/worker.js
@@ -43,6 +43,20 @@ function squareRoot(n, env) {
   return Math.sqrt(n);
 }
 
+function factorial(n) {
+  if (n < 0) {
+    throw new Error('Cannot calculate factorial of negative number');
+  }
+  if (n === 0 || n === 1) {
+    return 1;
+  }
+  let result = 1;
+  for (let i = 2; i <= n; i++) {
+    result *= i;
+  }
+  return result;
+}
+
 function validateApiKey(env) {
   const apiKey = env.TEST_API_KEY;
   if (!apiKey) {
@@ -87,6 +101,7 @@ export default {
               '/modulo': 'Modulo (remainder) of a divided by b (?a=10&b=3)',
               '/power': 'Calculate a^b (?a=2&b=3) [Premium]',
               '/sqrt': 'Square root of a (?a=16) [Premium]',
+              '/factorial': 'Calculate factorial of a (?a=5)',
               '/health': 'Health check',
             }
           }), { headers });
@@ -132,6 +147,11 @@ export default {
           result = squareRoot(a, env);
           break;
 
+        case '/factorial':
+          operation = 'factorial';
+          result = factorial(a);
+          break;
+
         default:
           return new Response(JSON.stringify({
             error: 'Not found',
@@ -142,7 +162,7 @@ export default {
       return new Response(JSON.stringify({
         operation,
         a,
-        b: operation === 'sqrt' ? undefined : b,
+        b: (operation === 'sqrt' || operation === 'factorial') ? undefined : b,
         result
       }), { headers });
 


### PR DESCRIPTION
## Summary

Add factorial operation to the calculator API.

## Changes
- Add `factorial(n)` function in `src/index.js` and `src/worker.js`
- Expose it at `GET /factorial?a=5` → returns `{"result": 120}`
- Handle edge cases: throw error if n < 0, return 1 if n is 0 or 1
- Add comprehensive tests for the factorial function
- All 22 tests passing

Fixes #7

Generated with [Claude Code](https://claude.ai/code)